### PR TITLE
fix: swallowed shape propagation failure after subgraph insertion

### DIFF
--- a/src/nn/variation/architecture_crossover.py
+++ b/src/nn/variation/architecture_crossover.py
@@ -460,7 +460,10 @@ def insert_subgraph(
     target_graph_module.graph.lint()
     target_graph_module.recompile()
 
-    # Shape propagation
+    # Shape propagation. ShapeProp executes the graph, so a failure here means
+    # the forward pass is broken and evaluation would fail anyway — re-raise so
+    # the child is rejected at variation time (before it occupies a GPU) and
+    # never carries stale tensor_meta into later shape-dependent logic.
     try:
         ShapeProp(target_graph_module).propagate(target_graph_module.example_input)
     except Exception:
@@ -471,6 +474,7 @@ def insert_subgraph(
                 logging.debug(f"{node.name}: {node.meta['tensor_meta'].shape}")
             else:
                 logging.debug(f"{node.name}: No shape info")
+        raise
 
     return target_graph_module, new_node_names
 


### PR DESCRIPTION
## Summary
- `insert_subgraph` ran post-insertion `ShapeProp` inside a try/except that logged and **continued**, so a crossover child with a broken graph could proceed to evaluation carrying stale/missing `tensor_meta`
- ShapeProp executes the model's forward — if it fails, evaluation is guaranteed to fail anyway, just later, more expensively (GPU reservation, eval startup), and misattributed as an evaluation failure instead of a crossover failure
- Now re-raises after the existing debug shape dump, so the child is rejected at variation time by the existing handler in `run_evolution`

## Test plan
- [ ] Run evolution and confirm broken crossovers appear as variation failures ("Error in crossover or mutation") rather than evaluation failures in the experiment record

🤖 Generated with [Claude Code](https://claude.com/claude-code)